### PR TITLE
修复小屏浏览器超出边框的bug，并且把月份星期的title替换成中文 #14 

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -19,9 +19,9 @@ const pickerModule = {
     const i18n = {
         previousMonth: 'Previous Month',
         nextMonth: 'Next Month',
-        months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-        weekdays: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-        weekdaysShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+	    months: ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+	    weekdays: ['周日', '周一', '周二', '周三', '周四', '周五', '周六'],
+	    weekdaysShort: ['日', '一', '二', '三', '四', '五', '六']
     }
     
     //options see https://github.com/dbushell/Pikaday#configuration.

--- a/js/src/picker.css
+++ b/js/src/picker.css
@@ -278,8 +278,8 @@
 
 .pika-lendar {
     float: left;
-    width: 6.4rem;
-    margin: 0.213rem;
+    /*width: 6.4rem;*/
+    /*margin: 0.213rem;*/
 }
 
 .pika-title {


### PR DESCRIPTION
<img width="346" alt="wx20171108-140552 2x" src="https://user-images.githubusercontent.com/13673008/32534533-b09cb264-c41b-11e7-8e94-4bd533b93106.png">
